### PR TITLE
Rewrite the bundle and bundler shebang to not specify the ruby version

### DIFF
--- a/bundler/build_test.go
+++ b/bundler/build_test.go
@@ -30,6 +30,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		timeStamp         time.Time
 		planRefinery      *fakes.BuildPlanRefinery
 		buffer            *bytes.Buffer
+		fileRewriter      *fakes.FileRewriter
 
 		build packit.BuildFunc
 	)
@@ -78,6 +79,8 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 		planRefinery = &fakes.BuildPlanRefinery{}
 
+		fileRewriter = &fakes.FileRewriter{}
+
 		timeStamp = time.Now()
 		clock = bundler.NewClock(func() time.Time {
 			return timeStamp
@@ -100,7 +103,14 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		buffer = bytes.NewBuffer(nil)
 		logEmitter := bundler.NewLogEmitter(buffer)
 
-		build = bundler.Build(entryResolver, dependencyManager, planRefinery, logEmitter, clock)
+		build = bundler.Build(
+			entryResolver,
+			dependencyManager,
+			planRefinery,
+			logEmitter,
+			clock,
+			fileRewriter,
+		)
 	})
 
 	it.After(func() {
@@ -192,6 +202,9 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		Expect(dependencyManager.InstallCall.Receives.Dependency).To(Equal(postal.Dependency{Name: "Bundler"}))
 		Expect(dependencyManager.InstallCall.Receives.CnbPath).To(Equal(cnbDir))
 		Expect(dependencyManager.InstallCall.Receives.LayerPath).To(Equal(filepath.Join(layersDir, "bundler")))
+
+		Expect(fileRewriter.RewriteCall.CallCount).To(Equal(1))
+		Expect(fileRewriter.RewriteCall.Receives.Filename).To(Equal(filepath.Join(layersDir, "bundler", "bin")))
 
 		Expect(buffer.String()).To(ContainSubstring("Some Buildpack some-version"))
 		Expect(buffer.String()).To(ContainSubstring("Resolving Bundler version"))
@@ -619,6 +632,28 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 					Layers: packit.Layers{Path: layersDir},
 				})
 				Expect(err).To(MatchError(ContainSubstring("permission denied")))
+			})
+		})
+
+		context("when the shebang can not be rewritten", func() {
+			it("returns an error", func() {
+				fileRewriter.RewriteCall.Returns.Error = errors.New("some-error")
+				_, err := build(packit.BuildContext{
+					CNBPath: cnbDir,
+					Plan: packit.BuildpackPlan{
+						Entries: []packit.BuildpackPlanEntry{
+							{
+								Name:    "bundler",
+								Version: "2.0.x",
+								Metadata: map[string]interface{}{
+									"version-source": "buildpack.yml",
+								},
+							},
+						},
+					},
+					Layers: packit.Layers{Path: layersDir},
+				})
+				Expect(err).To(MatchError(ContainSubstring("some-error")))
 			})
 		})
 	})

--- a/bundler/fakes/file_rewriter.go
+++ b/bundler/fakes/file_rewriter.go
@@ -1,0 +1,28 @@
+package fakes
+
+import "sync"
+
+type FileRewriter struct {
+	RewriteCall struct {
+		sync.Mutex
+		CallCount int
+		Receives  struct {
+			Filename string
+		}
+		Returns struct {
+			Error error
+		}
+		Stub func(string) error
+	}
+}
+
+func (f *FileRewriter) Rewrite(param1 string) error {
+	f.RewriteCall.Lock()
+	defer f.RewriteCall.Unlock()
+	f.RewriteCall.CallCount++
+	f.RewriteCall.Receives.Filename = param1
+	if f.RewriteCall.Stub != nil {
+		return f.RewriteCall.Stub(param1)
+	}
+	return f.RewriteCall.Returns.Error
+}

--- a/bundler/init_test.go
+++ b/bundler/init_test.go
@@ -17,5 +17,6 @@ func TestUnitBundler(t *testing.T) {
 	suite("LogEmitter", testLogEmitter)
 	suite("PlanEntryResolver", testPlanEntryResolver)
 	suite("PlanRefinery", testPlanRefinery)
+	suite("ShebangRewriter", testShebangRewriter)
 	suite.Run(t)
 }

--- a/bundler/shebang_rewriter.go
+++ b/bundler/shebang_rewriter.go
@@ -1,0 +1,36 @@
+package bundler
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"regexp"
+)
+
+type ShebangRewriter struct{}
+
+func NewShebangRewriter() ShebangRewriter {
+	return ShebangRewriter{}
+}
+
+func (sr ShebangRewriter) Rewrite(dir string) error {
+	files, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("Could not read directory: %w", err)
+	}
+
+	for _, file := range files {
+		fileContents, err := ioutil.ReadFile(filepath.Join(dir, file.Name()))
+		if err != nil {
+			return fmt.Errorf("Could not read file: %w", err)
+		}
+
+		shebangRegex := regexp.MustCompile(`^#!/.*ruby.*`)
+		fileContents = shebangRegex.ReplaceAll(fileContents, []byte("#!/usr/bin/env ruby"))
+		if err := ioutil.WriteFile(filepath.Join(dir, file.Name()), fileContents, 0755); err != nil {
+			return fmt.Errorf("Could not write file: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/bundler/shebang_rewriter_test.go
+++ b/bundler/shebang_rewriter_test.go
@@ -1,0 +1,82 @@
+package bundler_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cloudfoundry/bundler-cnb/bundler"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+)
+
+func testShebangRewriter(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect = NewWithT(t).Expect
+
+		shebangRewriter bundler.ShebangRewriter
+	)
+
+	it.Before(func() {
+		shebangRewriter = bundler.NewShebangRewriter()
+	})
+
+	context("Rewrite", func() {
+		var dir string
+
+		it.Before(func() {
+			var err error
+			dir, err = ioutil.TempDir("", "bin")
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(ioutil.WriteFile(filepath.Join(dir, "somescript"), []byte("#!/usr/bin/ruby2.5\n\n\n"), 0755)).To(Succeed())
+			Expect(ioutil.WriteFile(filepath.Join(dir, "anotherscript"), []byte("#!//bin/ruby2.6\n\n\n"), 0755)).To(Succeed())
+		})
+
+		it.After(func() {
+			Expect(os.RemoveAll(dir)).To(Succeed())
+		})
+
+		it("removes the ruby version from the shebang", func() {
+			Expect(shebangRewriter.Rewrite(dir)).To(Succeed())
+
+			fileContents, err := ioutil.ReadFile(filepath.Join(dir, "somescript"))
+			Expect(err).ToNot(HaveOccurred())
+
+			secondFileContents, err := ioutil.ReadFile(filepath.Join(dir, "anotherscript"))
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(string(fileContents)).To(HavePrefix("#!/usr/bin/env ruby"))
+			Expect(string(secondFileContents)).To(HavePrefix("#!/usr/bin/env ruby"))
+		})
+
+		context("error cases", func() {
+			context("when the directory can not be read", func() {
+				it("errors", func() {
+					Expect(os.RemoveAll(dir)).To(Succeed())
+
+					Expect(shebangRewriter.Rewrite(dir)).To(MatchError(ContainSubstring("Could not read directory")))
+				})
+			})
+
+			context("when a file could not be read", func() {
+				it("errors", func() {
+					Expect(os.Chmod(filepath.Join(dir, "somescript"), 0000)).To(Succeed())
+
+					Expect(shebangRewriter.Rewrite(dir)).To(MatchError(ContainSubstring("Could not read file")))
+				})
+			})
+
+			context("when a file could not be written", func() {
+				it("errors", func() {
+					Expect(os.Chmod(filepath.Join(dir, "somescript"), 0444)).To(Succeed())
+
+					Expect(shebangRewriter.Rewrite(dir)).To(MatchError(ContainSubstring("Could not write file")))
+				})
+			})
+
+		})
+	})
+}

--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -16,6 +16,14 @@ func main() {
 	dependencyManager := postal.NewService(cargo.NewTransport())
 	planRefinery := bundler.NewPlanRefinery()
 	clock := bundler.NewClock(time.Now)
+	shebangRewriter := bundler.NewShebangRewriter()
 
-	packit.Build(bundler.Build(entryResolver, dependencyManager, planRefinery, logEmitter, clock))
+	packit.Build(bundler.Build(
+		entryResolver,
+		dependencyManager,
+		planRefinery,
+		logEmitter,
+		clock,
+		shebangRewriter,
+	))
 }


### PR DESCRIPTION
This will rewrite the shebangs for the `bundle` and `bundler` executables that are installed by this buildpack so that they reference the `ruby` that is found on the `$PATH`. Details of why this is necessary can be found in https://github.com/cloudfoundry/binary-builder/issues/54.

This is a short-term addition to the buildpack so that we can unblock downstream buildpacks that are being broken by this strange shebangs that are currently included in the built dependency. Once https://github.com/cloudfoundry/binary-builder/issues/54 is resolved and we have new dependencies in this buildpack, we should be able to safely remove this code.